### PR TITLE
[#7] Article, ArticleComment 연관관계 수정

### DIFF
--- a/src/main/java/dev/be/gptboard/domain/Article.java
+++ b/src/main/java/dev/be/gptboard/domain/Article.java
@@ -3,6 +3,10 @@ package dev.be.gptboard.domain;
 import static javax.persistence.FetchType.*;
 import static lombok.AccessLevel.PROTECTED;
 
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -10,6 +14,8 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.OrderBy;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -31,6 +37,11 @@ public class Article extends AuditingFields{
 
     @Setter @Column(nullable = false, length = 10000) private String content;
 
+    @ToString.Exclude
+    @OrderBy("createdAt DESC")
+    @OneToMany(cascade = CascadeType.ALL)
+    private Set<ArticleComment> articleComments = new LinkedHashSet<>();
+
     private Article(Member member, String title, String content) {
         this.member = member;
         this.title = title;
@@ -39,5 +50,22 @@ public class Article extends AuditingFields{
 
     public static Article of(Member member, String title, String content) {
         return new Article(member, title, content);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Article)) {
+            return false;
+        }
+        Article article = (Article) o;
+        return getId().equals(article.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getId());
     }
 }

--- a/src/main/java/dev/be/gptboard/domain/ArticleComment.java
+++ b/src/main/java/dev/be/gptboard/domain/ArticleComment.java
@@ -24,23 +24,20 @@ public class ArticleComment extends AuditingFields {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Setter @ManyToOne(fetch = LAZY, optional = false) private Article article;
-
     @Setter @ManyToOne(fetch = LAZY, optional = false) private Member member;
 
     @Setter @Column(updatable = false) private Long parentCommentId;
 
     @Setter @Column(nullable = false, length = 500) private String content;
 
-    public ArticleComment(Article article, Member member, Long parentCommentId, String content) {
-        this.article = article;
+    public ArticleComment(Member member, Long parentCommentId, String content) {
         this.member = member;
         this.parentCommentId = parentCommentId;
         this.content = content;
     }
 
-    public static ArticleComment of(Article article, Member member, String content) {
+    public static ArticleComment of(Member member, String content) {
         /* 처음 생성한 댓글은 부모 댓글이 없다. */
-        return new ArticleComment(article, member, null, content);
+        return new ArticleComment(member, null, content);
     }
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -4,6 +4,6 @@ insert into article (member_id, title, content, created_at, created_by, modified
                                                                                                         (1, 'title-test-1', 'content-test-1', '2023-03-11 11:11:11', 'hankwanjin', '2023-03-12 11:11:11', 'hankwanjin'),
                                                                                                         (1, 'title-test-2', 'content-test-2', '2023-03-11 11:11:12', 'hankwanjin', '2023-03-12 11:11:12', 'hankwanjin'),
                                                                                                         (1, 'title-test-3', 'content-test-3', '2023-03-11 11:11:13', 'hankwanjin', '2023-03-12 11:11:13', 'hankwanjin');
-insert into article_comment (article_id, member_id, parent_comment_id, content, created_at, created_by, modified_at, modified_by) values
-                                                                                                                                          (1, 1, null, 'test-content-1', '2023-03-11 11:11:11', 'hankwanjin', '2023-03-12 11:11:11', 'hankwanjin'),
-                                                                                                                                          (1, 1,    1, 'test-content-2', '2023-03-11 11:11:11', 'hankwanjin', '2023-03-12 11:11:11', 'hankwanjin');
+insert into article_comment (member_id, parent_comment_id, content, created_at, created_by, modified_at, modified_by) values
+                                                                                                                                          (1, null, 'test-content-1', '2023-03-11 11:11:11', 'hankwanjin', '2023-03-12 11:11:11', 'hankwanjin'),
+                                                                                                                                          (1,    1, 'test-content-2', '2023-03-11 11:11:11', 'hankwanjin', '2023-03-12 11:11:11', 'hankwanjin');

--- a/src/test/java/dev/be/gptboard/repository/JpaRepositoryTest.java
+++ b/src/test/java/dev/be/gptboard/repository/JpaRepositoryTest.java
@@ -79,7 +79,6 @@ class JpaRepositoryTest {
         /*
          * 게시글을 지울 때 게시글과 관련된 댓글도 모두 지워줘야한다.
          */
-        articleCommentRepository.deleteAll();
         articleRepository.delete(article);
 
         //then


### PR DESCRIPTION
this closed: #7 

테스트 코드를 작성하던 도중 Article delete 시 ArticleComment도 같이 제거해주어야 함을 깨닫게 됨.

양방향 매핑으로 연관관계를 정할까했지만 양방향 매핑 시 생기는 여러가지 문제점 (무한 루프 문제, 연관관계의 불일치 문제, 객체의 상태 변경 문제)들이 생길 수 있어서 일대다 매핑을 하고 cascade ALL 옵션을 주어서 해결함.