### PR TITLE
[#9] querydsl에서 제공되는 검색 특화된 기능을 사용

### DIFF
--- a/src/main/java/dev/be/gptboard/repository/ArticleCommentRepository.java
+++ b/src/main/java/dev/be/gptboard/repository/ArticleCommentRepository.java
@@ -1,7 +1,29 @@
 package dev.be.gptboard.repository;
 
+import com.querydsl.core.types.dsl.DateTimeExpression;
+import com.querydsl.core.types.dsl.StringExpression;
 import dev.be.gptboard.domain.ArticleComment;
+import dev.be.gptboard.domain.QArticleComment;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
+import org.springframework.data.querydsl.binding.QuerydslBinderCustomizer;
+import org.springframework.data.querydsl.binding.QuerydslBindings;
 
-public interface ArticleCommentRepository extends JpaRepository<ArticleComment, Long> {
+public interface ArticleCommentRepository extends
+    JpaRepository<ArticleComment, Long>,
+    QuerydslPredicateExecutor<ArticleComment>,
+    QuerydslBinderCustomizer<QArticleComment>
+{
+    List<ArticleComment> findByArticle_Id(Long articleId);
+    void deleteByIdAndMember_Id(Long articleCommentId, Long memberId);
+
+    @Override
+    default void customize(QuerydslBindings bindings, QArticleComment root) {
+        bindings.excludeUnlistedProperties(true);
+        bindings.including(root.content, root.createdAt, root.createdBy);
+        bindings.bind(root.content).first(StringExpression::containsIgnoreCase);
+        bindings.bind(root.createdAt).first(DateTimeExpression::eq);
+        bindings.bind(root.createdBy).first(StringExpression::containsIgnoreCase);
+    }
 }

--- a/src/main/java/dev/be/gptboard/repository/ArticleRepository.java
+++ b/src/main/java/dev/be/gptboard/repository/ArticleRepository.java
@@ -1,8 +1,34 @@
 package dev.be.gptboard.repository;
 
+import com.querydsl.core.types.dsl.DateTimeExpression;
+import com.querydsl.core.types.dsl.StringExpression;
 import dev.be.gptboard.domain.Article;
+import dev.be.gptboard.domain.QArticle;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
+import org.springframework.data.querydsl.binding.QuerydslBinderCustomizer;
+import org.springframework.data.querydsl.binding.QuerydslBindings;
 
-public interface ArticleRepository extends JpaRepository<Article, Long> {
+public interface ArticleRepository extends
+    JpaRepository<Article, Long>,
+    QuerydslPredicateExecutor<Article>,
+    QuerydslBinderCustomizer<QArticle>
+{
+    Page<Article> findByTitleContaining(String title, Pageable pageable);
+    Page<Article> findByContentContaining(String content, Pageable pageable);
+    Page<Article> findByMember_NicknameContaining(String nickname, Pageable pageable);
 
+    void deleteByIdAndMember_Id(Long articleId, Long memberId);
+
+    @Override
+    default void customize(QuerydslBindings bindings, QArticle root) {
+        bindings.excludeUnlistedProperties(true);
+        bindings.including(root.title, root.content, root.createdAt, root.createdBy);
+        bindings.bind(root.title).first(StringExpression::containsIgnoreCase);
+        bindings.bind(root.content).first(StringExpression::containsIgnoreCase);
+        bindings.bind(root.createdAt).first(DateTimeExpression::eq);
+        bindings.bind(root.createdBy).first(StringExpression::containsIgnoreCase);
+    }
 }

--- a/src/main/java/dev/be/gptboard/repository/MemberRepository.java
+++ b/src/main/java/dev/be/gptboard/repository/MemberRepository.java
@@ -4,5 +4,4 @@ import dev.be.gptboard.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-
 }


### PR DESCRIPTION
this closed: #9 

ArticleRepository와 ArticleCommentRepository에
QuerydslPredicateExecutor와 QuerydslBinderCustomizer를 사용해서 검색과 바인딩 기능을 쓰도록 작성함.

